### PR TITLE
Add button and binding to dump all YAML files on home screen

### DIFF
--- a/client/src-tauri/src/commands.rs
+++ b/client/src-tauri/src/commands.rs
@@ -159,6 +159,42 @@ pub async fn make_dat(dat_descriptor: DatDescriptor, state: AppState<'_>) -> Res
 
 #[tauri::command]
 #[specta::specta]
+pub async fn make_all_yamls(state: AppState<'_>) -> Result<(), AppError> {
+    let dat_context = state
+        .read()
+        .dat_context
+        .clone()
+        .ok_or(anyhow!("No DAT context."))?;
+
+    let project_path = state
+        .read()
+        .project_path
+        .as_ref()
+        .ok_or(anyhow!("No project path specified."))?
+        .clone();
+
+    let processor = state.read().processor.clone();
+
+    let raw_data_dir = project_path.join(RAW_DATA_DIR);
+
+    Ok(walkdir::WalkDir::new(&raw_data_dir)
+        .into_iter()
+        .filter_map(|entry| {
+            let entry = entry.ok()?;
+            DatDescriptor::from_path(&entry.into_path(), &raw_data_dir, &dat_context)
+        })
+        .for_each(|dat_descriptor| {
+            let dat_context = dat_context.clone();
+            processor.dat_to_yaml(
+                dat_descriptor,
+                dat_context,
+                project_path.join(RAW_DATA_DIR),
+            );
+        }))
+}
+
+#[tauri::command]
+#[specta::specta]
 pub async fn make_yaml(dat_descriptor: DatDescriptor, state: AppState<'_>) -> Result<(), AppError> {
     let dat_context = state
         .read()

--- a/client/src-tauri/src/main.rs
+++ b/client/src-tauri/src/main.rs
@@ -34,6 +34,7 @@ fn main() {
             commands::get_working_files,
             commands::make_all_dats,
             commands::make_dat,
+            commands::make_all_yamls,
             commands::make_yaml,
         ],
         "../src/bindings.ts",
@@ -56,6 +57,7 @@ fn main() {
             commands::get_working_files,
             commands::make_all_dats,
             commands::make_dat,
+            commands::make_all_yamls,
             commands::make_yaml,
         ])
         .setup(|app| {

--- a/client/src/bindings.ts
+++ b/client/src/bindings.ts
@@ -50,6 +50,10 @@ export function makeDat(datDescriptor: DatDescriptor) {
     return invoke()<null>("make_dat", { datDescriptor })
 }
 
+export function makeAllYamls() {
+    return invoke()<null>("make_all_yamls")
+}
+
 export function makeYaml(datDescriptor: DatDescriptor) {
     return invoke()<null>("make_yaml", { datDescriptor })
 }

--- a/client/src/components/Home.tsx
+++ b/client/src/components/Home.tsx
@@ -14,9 +14,14 @@ function Home() {
       <hr />
       <ProjectSelect />
       <hr />
-      <button disabled={totalProcessingCount() > 0} onclick={() => totalProcessingCount() == 0 ? commands.makeAllDats() : undefined}>
-        Make all DATs
-      </button>
+      <div class="flex flex-row space-x-5">
+        <button disabled={totalProcessingCount() > 0} onclick={() => totalProcessingCount() == 0 ? commands.makeAllYamls() : undefined}>
+          Make all YAMLs
+        </button>
+        <button disabled={totalProcessingCount() > 0} onclick={() => totalProcessingCount() == 0 ? commands.makeAllDats() : undefined}>
+          Make all DATs
+        </button>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
👋 

I saw on all the sub-pages that there were options both export and make the relevant DAT files, but on the home page there was only a button to make all dat files.

Rust and this workflow are very new to me, so this is mostly copy/paste/replace.

EDIT: Got it
~~I managed to get it to build, but I can't figure out where to mark `make_all_yamls` as being used in a binding - any pointers?~~

~~Also, when I try to debug it, I get:~~

Build and setup itself is easy though: `cargo build`, etc.

I'm not sure what nomenclature you'd want when dealing with multiple YAML outputs, YAMLs feels a bit gross, let me know what you'd prefer!

EDIT2:
I eventually got it running, I needed to update to a more recent (I was very behind) `node`, update my `npm`. Before that I did `cargo install` for `tauri`, `tauri-cli` and `tauri-init`, I'm not sure if those were needed. I think I also did some install steps for `vite`, also not sure if that was needed.

~~My new button isn't horizontally aligned like I would have liked~~ 

It doesn't kick off the action, so I'll get back to this later today 🙏 

EDIT3:
I see whats up, I have everything hooked up correctly, but I'm iterating the wrong place

<img width="512" alt="image" src="https://github.com/InoUno/xi-tinkerer/assets/1389729/5c2f2111-7dc8-426c-8b52-f2172972af8f">
