### PR TITLE
Renaming ItemFlags: GmOnly, AugSendable

### DIFF
--- a/crates/dats/src/flags.rs
+++ b/crates/dats/src/flags.rs
@@ -29,8 +29,8 @@ bitflags! {
         const Ex = 0x6040; // NoAuction + NoDelivery + NoTrade
 
         // Simple Flags - mostly assumed meanings
-        const WallHanging = 0x0001; // Used by furnishing like paintings.
-        const Flag01 = 0x0002;
+        const AugSendable = 0x0001;
+        const GmOnly = 0x0002;      // Only wearable by GMs. This is only on the Judge's Gear.
         const MysteryBox = 0x0004;  // Can be gained from Gobbie Mystery Box
         const MogGarden = 0x0008;   // Can use in Mog Garden
         const CanSendPOL = 0x0010;


### PR DESCRIPTION
After digging into the Flag01 for items I came across the very few items this is currently on are all the Judge's gear and unimplemented/unnamed items. This updates the name and documentation for this flag.

**Testing Steps**
Eoport the Armor DAT
Search for Judge
See the flag name show up

<img width="307" height="197" alt="image" src="https://github.com/user-attachments/assets/202fec5f-0f6d-45b3-b760-64d4e530a916" />
