### PR TITLE
Spells: Range, AoE radius, AoE type

### DIFF
--- a/crates/dats/src/enums.rs
+++ b/crates/dats/src/enums.rs
@@ -235,6 +235,45 @@ pub enum JobEnum {
 }
 
 #[derive(
+    Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, FromPrimitive, IntoPrimitive,
+)]
+#[repr(u8)]
+pub enum SpellDistance {
+    #[default]
+    None = 0,
+    D1 = 1,
+    D3 = 2,
+    D4 = 3,
+    D5 = 4,
+    D6 = 5,
+    D7 = 6,
+    D8 = 7,
+    D10 = 8,
+    D12 = 9,
+    D14 = 10,
+    D16 = 11,
+    D20 = 12,
+    D25 = 13,
+    D30 = 14,
+    SelfTarget = 15,
+}
+
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, FromPrimitive, IntoPrimitive,
+)]
+#[repr(u8)]
+pub enum AreaShapeType {
+    Single = 0,
+    Sphere = 1,
+    Cone = 2,
+    CasterSphere = 3,
+
+    #[num_enum(catch_all)]
+    #[serde(untagged)]
+    Unknown(u8),
+}
+
+#[derive(
     Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, TryFromPrimitive, IntoPrimitive,
 )]
 #[repr(u32)]

--- a/crates/dats/src/formats/menu_table.rs
+++ b/crates/dats/src/formats/menu_table.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeMap;
 
 use crate::{
-    enums::{Element, JobEnum, MagicType, SkillType},
+    enums::{AreaShapeType, Element, JobEnum, MagicType, SkillType, SpellDistance},
     serde_base64, serde_hex,
     utils::{
         decode_data_block_masked, decode_text_block, encode_data_block_masked, encode_text_block,
@@ -265,7 +265,12 @@ pub struct MagicInfo {
     recast_time: u8,
     level_required: BTreeMap<JobEnum, u16>,
     id: u16,
-    icon_id: u8,
+    icon_id: u16,
+    unknown_0x42: u16,
+    unknown_0x44: u8,
+    range: SpellDistance,
+    aoe_range: SpellDistance,
+    area_shape: AreaShapeType,
 
     #[serde(with = "serde_hex")]
     unknowns: Vec<u8>,
@@ -304,6 +309,11 @@ impl SectionInfo for MagicInfo {
                 .collect(),
             id: data_walker.step()?,
             icon_id: data_walker.step()?,
+            unknown_0x42: data_walker.step()?,
+            unknown_0x44: data_walker.step()?,
+            range: SpellDistance::from(data_walker.step::<u8>()?),
+            aoe_range: SpellDistance::from(data_walker.step::<u8>()?),
+            area_shape: AreaShapeType::from(data_walker.step::<u8>()?),
 
             unknowns: data_walker
                 .take_bytes(data_walker.remaining() - 1)?
@@ -343,6 +353,11 @@ impl SectionInfo for MagicInfo {
 
         data_walker.write(self.id);
         data_walker.write(self.icon_id);
+        data_walker.write(self.unknown_0x42);
+        data_walker.write(self.unknown_0x44);
+        data_walker.write::<u8>(self.range.into());
+        data_walker.write::<u8>(self.aoe_range.into());
+        data_walker.write::<u8>(self.area_shape.into());
         data_walker.write_bytes(&self.unknowns);
 
         data_walker.write::<u8>(0xFF);


### PR DESCRIPTION
Adds the following fields to spells structure:
- Range/Distance
- AoE radius
- AoE type

Note that Range and Radius are stored as indices to a LUT stored in the client. I have it [documented here](https://sruonlsb.notion.site/FFXI-Range-Radius-testing-2b23768470138076bf5cfa5020e375bc)

There are a couple more fields I have reversed but I'm not 100% on the exact meaning of all bitflags so they'll be for another time.